### PR TITLE
keymaster: add support for skeymast

### DIFF
--- a/keymaster_qcom.cpp
+++ b/keymaster_qcom.cpp
@@ -794,6 +794,9 @@ static int qcom_km_open(const hw_module_t* module, const char* name,
     if(ret)
         ret = (*km_handle->QSEECom_start_app)((struct QSEECom_handle **)&km_handle->qseecom,
                         "/firmware/image", "keymaste", KM_SB_LENGTH);
+    if(ret)
+        ret = (*km_handle->QSEECom_start_app)((struct QSEECom_handle **)&km_handle->qseecom,
+                        "/firmware/image", "skeymast", KM_SB_LENGTH);
     if (ret) {
         ALOGE("Loading keymaster app failed");
         free(km_handle);


### PR DESCRIPTION
Samsung introduces skeymast into Marshmallow NON-HLOS.bin.
thanks @Pafcholini.
original thread here https://github.com/Emotroid-Rom/android_hardware_qcom_keymaster/commit/4d6f11b5b085273644def78bda1aa1fb7a980602